### PR TITLE
fix: api test on deployment pipeline

### DIFF
--- a/.devops/azure-templates/api-tests.yml
+++ b/.devops/azure-templates/api-tests.yml
@@ -13,6 +13,11 @@ parameters:
 
 
 steps:
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: $(Build.Repository.LocalPath)
+      Contents: '**'
+      TargetFolder: $(Agent.TempDirectory)
   - task: Bash@3
     name: newman_run_command
     displayName: 'Set Newman run command'
@@ -23,20 +28,24 @@ steps:
         echo "Newman run command: [$NEWMAN_TEST_RUN]"
         echo "##vso[task.setvariable variable=value;isOutput=true]$NEWMAN_TEST_RUN"
       failOnStderr: true
+      workingDirectory: $(Agent.TempDirectory)
   - ${{ if eq(parameters['USE_NEWMAN_DOCKER_IMAGE'], False) }}:
       - script: |
           yarn global add newman
         displayName: 'Newman installation'
+        workingDirectory: $(Agent.TempDirectory)
       - script: |
           newman $(newman_run_command.value)
         displayName: 'Run api test'
+        workingDirectory: $(Agent.TempDirectory)
   - ${{ else }}:
       - script: |
-          docker run -v .:/etc/newman -t postman/newman $(newman_run_command.value)
+          docker run --rm -v .:/etc/newman -t postman/newman $(newman_run_command.value)
         displayName: 'Run api test'
+        workingDirectory: $(Agent.TempDirectory)
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     inputs:
       testResultsFormat: 'JUnit'
       testResultsFiles: '**/*-TEST.xml'
-      searchFolder: '$(System.DefaultWorkingDirectory)'
+      searchFolder: '$(Agent.TempDirectory)'


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Execute tests in agent temp directory instead of default folder
<!--- Describe your changes in detail -->

#### Motivation and Context
Make use of temp folder that is cleaned at each job run in order to avoid job executions error (see [here](https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=223309&view=logs&j=2978637f-4005-5664-fb3e-1b63ec5f9f43&t=dd6c5e91-51ac-5b14-cfb0-f34ac616a58a) for an example) checking out files from repo due to the fact that there are modified files from previous executions
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Pipeline [execution](https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=223418&view=results) 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.